### PR TITLE
Fix ament_libraries_deduplicate regex

### DIFF
--- a/ament_cmake_libraries/cmake/ament_libraries_deduplicate.cmake
+++ b/ament_cmake_libraries/cmake/ament_libraries_deduplicate.cmake
@@ -26,9 +26,9 @@
 # @public
 #
 macro(ament_libraries_deduplicate VAR)
-  string(REGEX REPLACE "(^|;)(debug|optimized|general);(.+)" "\\2${AMENT_BUILD_CONFIGURATION_KEYWORD_SEPARATOR}\\3" _packed "${ARGN}")
+  string(REGEX REPLACE "(^|;)(debug|optimized|general);([^;]+)" "\\1\\2${AMENT_BUILD_CONFIGURATION_KEYWORD_SEPARATOR}\\3" _packed "${ARGN}")
   list(REVERSE _packed)
   list(REMOVE_DUPLICATES _packed)
   list(REVERSE _packed)
-  string(REGEX REPLACE "(^|;)(debug|optimized|general)${AMENT_BUILD_CONFIGURATION_KEYWORD_SEPARATOR}(.+)" "\\2;\\3" ${VAR} "${_packed}")
+  string(REGEX REPLACE "(^|;)(debug|optimized|general)${AMENT_BUILD_CONFIGURATION_KEYWORD_SEPARATOR}([^;]+)" "\\1\\2;\\3" ${VAR} "${_packed}")
 endmacro()


### PR DESCRIPTION
see https://github.com/ament/ament_cmake/pull/448#issuecomment-1972259031

Only impact if debug/optimized/general keywords are used (but they aren't AFAIK)